### PR TITLE
Refactor Slack component into View and Container

### DIFF
--- a/src/components/Slack.js
+++ b/src/components/Slack.js
@@ -1,11 +1,8 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 
-class Slack extends React.Component {
+class SlackContainer extends React.Component {
 
-
-
-  constructor (props){
+  constructor (props) {
     super(props);
     this.loadData = this.loadData.bind(this);
   }
@@ -22,15 +19,12 @@ class Slack extends React.Component {
 
   async loadData() {
     try {
-      const res = await fetch('https://m7cwj1fy7c.execute-api.us-west-2.amazonaws.com/mlhtest/dayof-slack',
-        {
-          mode: 'cors',
-          credentials: 'omit'
-        });
-      const blocks = await res.json();
-      const dataBody = blocks;
+      const res = await fetch('https://m7cwj1fy7c.execute-api.us-west-2.amazonaws.com/mlhtest/dayof-slack', {
+        mode: 'cors',
+        credentials: 'omit'
+      });
       this.setState({
-        text: blocks.body
+        text: await res.json()
       });
     } catch (e) {
       console.log(e);
@@ -38,38 +32,30 @@ class Slack extends React.Component {
   }
 
   render () {
-    const clearBraColon = (msg) => {
-      let acc = '';
-      let braColon = false;
-      let lstIdx = 0;
-	  if(msg) {
-		  for(let i = 0; i < msg.length; i++){
-          if((msg[i] === '<' || msg[i] === ':') && !braColon){
-			  acc += msg.substring(lstIdx, i);
-			  braColon = true;
-          }else if(braColon && (msg[i] === '>' || msg[i] === ':')){
-			  lstIdx = i + 1;
-			  braColon = false;
-        	}
-      	}
-	  
+    const formatMessage = (key) => ({
+      // Strip brackets and colon artifacts from slack
+      text: key.replace(/(:[^:]*:)|(<[^>]*>)/g, ''),
+      date: new Date(key.ts * 1000).toLocaleDateString(),
+      time: new Date(key.ts * 1000).toLocaleTimeString()
+    });
 
-        acc += msg.substring(lstIdx);
-	  }
-      return acc;
-    };
+    return <SlackView messages={this.state.text.map(formatMessage)} />;
+  }
+}
 
+class SlackView extends React.Component {
+  render() {
     return (
       <div className="">
-        {this.state.text && this.state.text.map(key =>
+        {this.props.messages.map(message =>
           <span>
-            <h5 className="content-title">{clearBraColon(key.text)}</h5>
-            <p className="content-desc mb-3">Posted on  {new Date(key.ts*1000).toLocaleDateString()} at {new Date(key.ts*1000).toLocaleTimeString()}</p>
+            <h5 class="content-title">{message.text}</h5>
+            <p class="content-desc mb-3">Posted on  {message.date} at {message.time}</p>
           </span>
         )}
-
       </div>
     );
   }
 }
-export default Slack;
+
+export default SlackContainer;


### PR DESCRIPTION
Additionally fix the bug where :text> matches the Slack :emote: and <channel> stripping code.

Ez mentioned something about refactoring Slack into a separate View and Container, so I took a stab at that. Considering how tightly coupled they are, I wasn't sure if they should have separate files.

Resolves #18 