### PR TITLE
Removed misleading error message

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -347,9 +347,7 @@ class Profile {
                 if (error) {
                     callback("An error occured when attempting to reset password");
                 } else {
-                    if (body.errorMessage && body.errorMessage.includes("timed out")) {
-                        callback("Link expired");
-                    } else if (body.errorMessage) {
+                    if (body.errorMessage) {
                         callback(body.errorMessage);
                     } else if (body.statusCode === 200) {
                         callback();


### PR DESCRIPTION
I guess we (lo key meaning I) misinterpreted "timed out" for being "Link Expired" oops