### PR TITLE
Updated Magic Links

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -229,6 +229,7 @@ input, textarea, .custom-file-label {
 .custom-av-checkbox div div label p {
     color: var(--input-color);
 }
+
 /* Form validator */
 .avfield-hide-inner {
     visibility: hidden;
@@ -238,4 +239,22 @@ input, textarea, .custom-file-label {
 }
 .custom-av-checkbox .is-invalid div label p {
     color: var(--accent-color) !important;
+}
+
+/* Dashboard Alerts */
+.profile-alert {
+    border: none !important;
+    color: white !important;
+}
+.profile-alert.profile-alert-success {
+    background: rgba(0, 255, 0, 0.25) !important;
+}
+.profile-alert.profile-alert-danger {
+    background: rgba(255, 0, 0, 0.25) !important;
+}
+.profile-alert.profile-alert-info {
+    background: rgba(0, 255, 255, 0.25) !important;
+}
+.profile-alert.profile-alert-warning {
+    background: rgba(255, 255, 0, 0.25) !important;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,6 +28,7 @@ class App extends Component {
         super(props);
         this._event_onResize = this._event_onResize.bind(this);
         this.setMagic = this.setMagic.bind(this);
+        this.clearMagic = this.clearMagic.bind(this);
         this.getComponentProps = this.getComponentProps.bind(this);
         this.dismissLoggedOutAlert = this.dismissLoggedOutAlert.bind(this);
         window.addEventListener("resize", this._event_onResize);
@@ -45,10 +46,11 @@ class App extends Component {
      */
     componentWillMount() {
         this._event_onResize();
+        let prof = new Profile();
         this.setState({
-            profile: new Profile(),
+            profile: prof,
             loggedout: false,
-            magic: ""
+            magic: prof.GetMagic() // In case there is already a magic link, we need to load it in.
         });
     }
     /**
@@ -56,7 +58,15 @@ class App extends Component {
      * @param {String} magic Magic link from lcs 
      */
     setMagic(magic) {
+        this.state.profile.SetMagic(magic);
         this.setState({ magic });
+    }
+    /**
+     * Reset the magic link in both the state and cookies
+     */
+    clearMagic() {
+        this.state.profile.ClearMagic();
+        this.setState({ magic: "" });
     }
     /**
      * Dismiss the log out alert
@@ -72,7 +82,8 @@ class App extends Component {
     getComponentProps() {
         return {
             magic: this.state.magic,
-            setMagic: this.state.setMagic,
+            setMagic: this.setMagic,
+            clearMagic: this.clearMagic,
             isMobile: this.state.isMobile,
             profile: this.state.profile,
             loggedout: this.state.loggedout,

--- a/src/components/Dashboard/Dashboard.jsx
+++ b/src/components/Dashboard/Dashboard.jsx
@@ -18,6 +18,21 @@ class Dashboard extends Component {
         profileMSG: null
     }
     componentWillMount() {
+        if (this.props.magic) {
+            this.props.profile.Eat(this.props.magic, (msg) => {
+                if (msg) {
+                    console.error(msg);
+                    this.setState({
+                        profileMSG: { color: "warning", value: msg }
+                    });
+                } else {
+                    this.setState({
+                        profileMSG: { color: "info", value: "Magic link applied!" }
+                    });
+                }
+                this.props.clearMagic();
+            });
+        }
         this.props.profile.Get((msg, data) => {
             if (msg) {
                 console.error(msg);
@@ -45,8 +60,8 @@ class Dashboard extends Component {
                 this.setState({
                     loading: false,
                     profileMSG: err ?
-                        { success: true, value: err } :
-                        { success: false, value: 'Profile Updated!' }
+                        { color: "danger", value: err } :
+                        { color: "success", value: 'Profile Updated!' }
                 })
             });
         });

--- a/src/components/Dashboard/ProfileMessage.jsx
+++ b/src/components/Dashboard/ProfileMessage.jsx
@@ -1,14 +1,13 @@
 import React from "react";
-import { UncontrolledAlert } from 'reactstrap';
+import { UncontrolledAlert } from "reactstrap";
 /**
  * Renders an alert based on the message
  * @param {String} message The displayed message 
  */
 const ProfileMessage = ({ message }) => (
-    message && <UncontrolledAlert
-            color={message.success ? 'success' : 'danger'}
-            style={{ background: "rgba(0, 255, 0, 0.25)", border: "none", color: "white" }} >
-        { message.value }
-    </UncontrolledAlert>
+    message &&
+        <UncontrolledAlert color={message.color} className={`profile-alert profile-alert-${message.color}`}>
+            {message.value}
+        </UncontrolledAlert>
 )
 export default ProfileMessage

--- a/src/components/Magic.jsx
+++ b/src/components/Magic.jsx
@@ -4,8 +4,7 @@ import { theme } from "../Defaults";
 import { Icon } from "react-fa";
 import { Link } from "react-router-dom";
 import { RingLoader } from "react-spinners";
-import LoginPage from "./Login";
-
+import { Redirect } from "react-router-dom";
 /**
  * Magic link handler component
  */
@@ -16,6 +15,8 @@ class MagicPage extends Component {
         this.renderLogin = this.renderLogin.bind(this);
     }
     componentWillMount() {
+        let mlurl = this.props.match.params.mlurl;
+        this.props.setMagic(mlurl);
         this.setState({
             loading: false,
             done: false,
@@ -132,7 +133,7 @@ class MagicPage extends Component {
      * Render login component
      */
     renderLogin() {
-        return <LoginPage {...this.props} />
+        return <Redirect to="/login" />
     }
 }
 

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -63,6 +63,10 @@ const ENDPOINTS = {
      * Reset password from magic link to reset password
      */
     "resetpassword": BASE + "/consume",
+    /**
+     * Digest magic links
+     */
+    "magic": BASE + "/consume",
 }
 /**
  * Standard profile handler for the entire application
@@ -73,9 +77,9 @@ class Profile {
         this.Logout = this.Logout.bind(this);
         this.SignUp = this.SignUp.bind(this);
         this._login = this._login.bind(this);
-        this._token = cookie.load("token");
-        this._email = cookie.load("email");
-        this._valid_until = Date.parse(cookie.load("valid_until"));
+        this._token = cookie.load("token", { path: "/" });
+        this._email = cookie.load("email", { path: "/" });
+        this._valid_until = Date.parse(cookie.load("valid_until", { path: "/" }));
         if (this._token && this._email && this._valid_until && this._valid_until > Date.now()) {
             this.isLoggedIn = true;
         } else {
@@ -221,6 +225,7 @@ class Profile {
         cookie.remove("token");
         cookie.remove("email");
         cookie.remove("valid_until");
+        cookie.remove("magic");
         this._token = null;
         this._email = null;
         this._valid_until = null;
@@ -348,6 +353,45 @@ class Profile {
                 }
             });
         }
+    }
+    Eat(magic, callback) {
+        if (!magic) {
+            callback("Input a valid magic link");
+        } else if (!this.isLoggedIn) {
+            callback("User needs to be logged in");
+        } else {
+            request({
+                method: "POST",
+                uri: ENDPOINTS.magic,
+                body: {
+                    email: this._email,
+                    link: magic,
+                    auth: this._token
+                },
+                json: true
+            }, (error, response, body) => {
+                if (error) {
+                    callback("An error occured while digesting the magic link");
+                } else {
+                    if (body.errorMessage) {
+                        callback(body.errorMessage);
+                    } else if (body.statusCode === 200) {
+                        callback();
+                    } else {
+                        callback((body.body) ? (body.body) : ("Unexpected Error"));
+                    }
+                }
+            });
+        }
+    }
+    ClearMagic() {
+        cookie.remove("magic", { path: "/" });
+    }
+    SetMagic(magic) {
+        cookie.save("magic", magic, { path: "/" });
+    }
+    GetMagic() {
+        return cookie.load("magic", { path: "/" });
     }
 }
 

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -366,7 +366,7 @@ class Profile {
                 body: {
                     email: this._email,
                     link: magic,
-                    auth: this._token
+                    token: this._token
                 },
                 json: true
             }, (error, response, body) => {


### PR DESCRIPTION
> Remember when we first implemented magic links, we said _"lets do forgot now, and we'll implement the rest later?"_
## Updates
 - `/magic/:mlurl` stores the magic link parameter as a state in `<App/>` to be passed down
 - Once the user goes to `/dashboard`, if there is a magic link, it will send it to lcs (this is handled in dashboard and not in signup/login since this means its only handled in one, centralized place, it ensures that the user is logged in with a valid token/email, and it means if the user is already signed into the website, and clicks the link from their email, it will automatically apply it to them without having the user resign in)
 - Initial state handled through cookies
 - Added `{ path: "/" }` to cookie handler to force cookie storage at the root level of the website. (If not handled, a cookie add request while in `/magic/:mlurl` will add the cookie to the `/magic` root, which makes it inaccessible for the rest of the components)
 - New `consume` wrapper function `Eat` in profile to handle this request
 - Generalized `ProfileMessage` to include more than success/danger bootstrap styles (externalized styles to css)