### PR TITLE
Remove the edit button from the user form

### DIFF
--- a/src/components/Dashboard/Forms/UserProfileForm/UserProfileForm.jsx
+++ b/src/components/Dashboard/Forms/UserProfileForm/UserProfileForm.jsx
@@ -428,17 +428,12 @@ class UserProfileForm extends Component {
                         {user.registration_status === "registered" ? <p style={{ ...pStyle, height: 100 }}>I have read and agree to the <a href="https://static.mlh.io/docs/mlh-code-of-conduct.pdf">MLH Code of Conduct</a> and I authorize you to share my application/registration information for event administration, ranking, MLH administration, pre- and post-event informational e-mails, and occasional messages about hackathons in-line with the <a href="https://mlh.io/privacy">MLH Privacy Policy</a>. Further, I agree to the terms of both the <a href="https://github.com/MLH/mlh-policies/blob/master/prize-terms-and-conditions/contest-terms.md">MLH Contest Terms and Conditions</a> and the <a href="https://mlh.io/privacy">MLH Privacy Policy</a>.</p>
                             : <p style={{...pStyle, color: theme.accent[0] }}>You have not yet agreed to MLH policies. Please fill out your user profile.</p>}
                     </FormGroup>
-                    <div style={{ width: "100%" }}
-                        align="right">
-                        <Button style={{ backgroundColor: theme.primary[0] }}
-                            onClick={() => { this.setState({ edit: true }); }}>Edit</Button>
-                    </div>
                 </div>
             );
         }
     }
 }
-                
+
 
 UserProfileForm.propTypes = {
     user: {


### PR DESCRIPTION
The button with the edit icon is sufficient, and the button text is wrong with the new colors

The old button:
![image](https://user-images.githubusercontent.com/7978904/63309165-c7eb2b00-c2c3-11e9-815e-6beb95bf5d0d.png)

The form without the button:
![image](https://user-images.githubusercontent.com/7978904/63309174-d1749300-c2c3-11e9-8984-54c7a1123601.png)

