### PR TITLE
Fix excessive re-rendering of the resume uploader

### DIFF
--- a/src/components/Dashboard/Forms/UserProfileForm/ResumeUploader.jsx
+++ b/src/components/Dashboard/Forms/UserProfileForm/ResumeUploader.jsx
@@ -15,7 +15,7 @@ const ResumeUploader = React.memo(({ edit, profile }) => {
                     "Choose a file to upload" :
                     "Nothing yet")
             );
-        })
+        });
     });
 
     const onUpload = async (event) => {


### PR DESCRIPTION
This does two things: put the network request in an 'effect' so it only gets called when necessary, and indicates to React that the component should only be re-rendered when the props change.