### PR TITLE
Use React.memo wherever possible

### DIFF
--- a/src/components/Dashboard/ApplicationStatus.jsx
+++ b/src/components/Dashboard/ApplicationStatus.jsx
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
  * Turn the 'registration_status' from LCS into something user-friendly
  * @param {String} status Render the status of the users application
  */
-const ApplicationStatus = ({ status, onComing, onNotComing, reimbursement }) => (
+const ApplicationStatus = React.memo(({ status, onComing, onNotComing, reimbursement }) =>
     <div style={{ marginBottom: 10 }}>
         <div style={{ width: "100%", textAlign: "left" }}>
             <p className="lead">Application Status</p>

--- a/src/components/Dashboard/Forms/TravelReimbursementsForm.jsx
+++ b/src/components/Dashboard/Forms/TravelReimbursementsForm.jsx
@@ -25,7 +25,7 @@ const label_obj = (mode) => ({
     label: MODE_LABELS[mode] || mode,
 });
 
-const TravelReimbursementsForm = ({ travelling_from, onSubmit }) => {
+const TravelReimbursementsForm = React.memo(({ travelling_from, onSubmit }) => {
     // If no travel object is provided, initialize all fields to falsey values
     const travel_state = travelling_from || {
         is_real: false,
@@ -169,7 +169,7 @@ const TravelReimbursementsForm = ({ travelling_from, onSubmit }) => {
             </div>}
         </Form>
     );
-};
+});
 
 TravelReimbursementsForm.propTypes = {
     travelling_from: PropTypes.string,

--- a/src/components/Dashboard/Loading.jsx
+++ b/src/components/Dashboard/Loading.jsx
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
  * Render a loading  screen
  * @param {String} Text Loading subtext
  */
-const Loading = ({ text }) => (
+const Loading = React.memo(({ text }) =>
     <Container fluid
         style={{ width: "100%", minHeight: "100vh", textAlign: "center", backgroundColor: theme.secondary[1] }}
         className="d-flex align-items-center">

--- a/src/components/Dashboard/ProfileMessage.jsx
+++ b/src/components/Dashboard/ProfileMessage.jsx
@@ -4,7 +4,7 @@ import { UncontrolledAlert } from "reactstrap";
  * Renders an alert based on the message
  * @param {String} message The displayed message 
  */
-const ProfileMessage = ({ message }) => (
+const ProfileMessage = React.memo(({ message }) =>
     message &&
         <UncontrolledAlert color={message.color}
             className={`profile-alert profile-alert-${message.color}`}>

--- a/src/components/Dashboard/QR.jsx
+++ b/src/components/Dashboard/QR.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-const QR = ({ data, status }) => (
+const QR = React.memo(({ data, status }) =>
     (status === "confirmed" || status === "waitlist" || status ==="coming" || status ==="registered") && data && data.body && <div>
         <img src={data.body}
             className="qr"

--- a/src/components/GlowButton.jsx
+++ b/src/components/GlowButton.jsx
@@ -3,7 +3,7 @@ import { Button } from "reactstrap";
 import { Icon } from "react-fa";
 import PropTypes from "prop-types";
 
-const GlowButton = ({ href, icon, text }) => (
+const GlowButton = React.memo(({ href, icon, text }) =>
     <Button href={href}
         className="live-links"
         size="lg"

--- a/src/components/Landing/Sections/Stats.jsx
+++ b/src/components/Landing/Sections/Stats.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Row, Col } from "reactstrap";
 import PropTypes from "prop-types";
 
-const Stats = () => (
+const Stats = React.memo(() =>
     <div>
         <h1 className="display-4 theme-font">The Numbers</h1>
         <hr />

--- a/src/components/Team/Person.jsx
+++ b/src/components/Team/Person.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { theme } from "../../Defaults";
 import PropTypes from "prop-types";
 
-const Person = ({ image, name, title }) => (
+const Person = React.memo(({ image, name, title }) =>
     <div style={{marginBottom: 10}}>
         {
             image && <img style={{ borderRadius:80 }}

--- a/src/components/Team/TeamNames.jsx
+++ b/src/components/Team/TeamNames.jsx
@@ -3,7 +3,7 @@ import {Col } from "reactstrap";
 import Person from "./Person.jsx";
 import PropTypes from "prop-types";
 
-const TeamNames = ({ people, teamName }) => (
+const TeamNames = React.memo(({ people, teamName }) =>
     <Col>
         <h4> {teamName} </h4>
         {people.map((person) =>

--- a/src/library/AuthForm.jsx
+++ b/src/library/AuthForm.jsx
@@ -16,7 +16,7 @@ Props:
 - onSubmit: the actual function of the form
 - title: the form title
 */
-const AuthForm = ({ children, errors, label, loading, isMobile, onSubmit, title }) => (
+const AuthForm = React.memo(({ children, errors, label, loading, isMobile, onSubmit, title }) =>
     <Container
         fluid
         style={{ width: "100%", minHeight: "100vh", textAlign: "center", backgroundColor: theme.secondary[1] }}


### PR DESCRIPTION
It turns out that we can just slap React.memo on any component that
should only re-render for props changes and it will improve perf.