### PR TITLE
Fix Dashboard Loading Visibility

### DIFF
--- a/src/components/Dashboard/Loading.jsx
+++ b/src/components/Dashboard/Loading.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Container } from "reactstrap";
+import { Grid } from "@material-ui/core";
 import { BounceLoader, PulseLoader } from "react-spinners";
 import { theme } from "../../Defaults";
 import PropTypes from "prop-types";
@@ -9,26 +9,34 @@ import PropTypes from "prop-types";
  * @param {String} Text Loading subtext
  */
 const Loading = ({ text }) => (
-    <Container fluid
+    <Grid 
+        container
+        justify="center"
+        alignItems="center"
         style={{ width: "100%", minHeight: "100vh", textAlign: "center" }}
         className="d-flex align-items-center">
-        <div style={{ width: "100%", color: theme.accent[0] }}
-            align="center">
-            <div style={{ display: "inline-block" }}>
-                <h1 className="display-1">L</h1>
+        <Grid
+            item
+            xs={6}
+            style={{ display: "block", zIndex: 3, backgroundColor: theme.secondary[1], color: "white", boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.5)" }}>
+            <div style={{ width: "100%", color: theme.accent[0] }}
+                align="center">
+                <div style={{ display: "inline-block" }}>
+                    <h1 className="display-1">L</h1>
+                </div>
+                <div style={{ display: "inline-block" }}>
+                    <BounceLoader color={theme.accent[0]} />
+                </div>
+                <div style={{ display: "inline-block" }}>
+                    <h1 className="display-1">ading</h1>
+                </div>
+                <div style={{ display: "inline-block" }}>
+                    <PulseLoader color={theme.accent[0]} />
+                </div>
+                <p className="lead"> { text } </p>
             </div>
-            <div style={{ display: "inline-block" }}>
-                <BounceLoader color={theme.accent[0]} />
-            </div>
-            <div style={{ display: "inline-block" }}>
-                <h1 className="display-1">ading</h1>
-            </div>
-            <div style={{ display: "inline-block" }}>
-                <PulseLoader color={theme.accent[0]} />
-            </div>
-            <p className="lead"> { text } </p>
-        </div>
-    </Container>
+        </Grid>
+    </Grid>
 );
 Loading.propTypes = {
     text: PropTypes.string,


### PR DESCRIPTION
- Added card to background of loading
- Converted to MaterialUI

Files Changed:
`Dashboard/Loading.jsx`

