### PR TITLE
Update birth date and SEO description

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -16,11 +16,11 @@
 <head>
     <meta charset="utf-8">
     <meta property="og:url" content="https://www.hackru.org/" />
-    <meta property="og:title" content="HackRU Spring 2021" />
+    <meta property="og:title" content="HackRU Fall 2021" />
     <meta property="og:description" content="Get hyped for the best Hackathon that Rutgers has to offer!" />
     <meta property="og:image" content="./assets/fb-banner-upper.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Find out more about HackRU Spring 2021.">
+    <meta name="description" content="Find out more about HackRU Fall 2021.">
     <link rel="icon" href="%PUBLIC_URL%/assets/icons/red_hackru.png">
     <link rel="shortcut icon" href="%PUBLIC_URL%/assets/icons/red)hackru.png">
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">

--- a/src/components/Dashboard/Forms/UserProfileForm/ProfileCards/About.jsx
+++ b/src/components/Dashboard/Forms/UserProfileForm/ProfileCards/About.jsx
@@ -133,7 +133,7 @@ class About extends Component {
                                             value: "01/01/1920"
                                         },
                                         end: {
-                                            value: "04/17/2003"
+                                            value: "10/16/2003"
                                         }
                                     } }} />
                         </Col>


### PR DESCRIPTION

# Description

- Updated end birthdate to 10/16/2003 for registration/profile.
- Updated site description metadata (for Google search) and title tag (for social media sharing) to Fall 2021.

## Birthdate demo

https://user-images.githubusercontent.com/30333942/134272195-0cb93df8-b30d-49f1-84b0-813ad23dc235.mp4
