### PR TITLE
Close schedule from home page

### DIFF
--- a/src/Defaults.js
+++ b/src/Defaults.js
@@ -56,13 +56,13 @@ const navlinks = {
         fullHeight: false,
         component: (props) => <About {...props} />,
     },
-    SCHEDULE: {
-        url: "#schedule",
-        enabled: !defaults.freeze,
-        hideLink: false,
-        fullHeight: false,
-        component: (props) => <Schedule {...props} />,
-    },
+    // SCHEDULE: {
+    //     url: "#schedule",
+    //     enabled: !defaults.freeze,
+    //     hideLink: false,
+    //     fullHeight: false,
+    //     component: (props) => <Schedule {...props} />,
+    // },
     // "SPONSORS": {
     //     "url": "#sponsors",
     //     "enabled": !defaults.freeze,


### PR DESCRIPTION
# Description

Omitted schedule from home page. Useful in cases like having the site live without it until we edit and add the schedule near the event date.

# Demo

https://user-images.githubusercontent.com/30333942/134406593-578e14d6-6e2c-473c-86ca-bb73e4ccf143.mp4


