### PR TITLE
TeamRU Explore Page | Team search box and matches pagination

### DIFF
--- a/src/Defaults.js
+++ b/src/Defaults.js
@@ -33,7 +33,7 @@ const defaults = {
         "https://s3-us-west-2.amazonaws.com/hackru-internal/partners-logos/",
     teamInfo: "https://s3-us-west-2.amazonaws.com/hackru-internal/hackru-team/",
     freeze: false,
-    teamru: true,
+    teamru: false,
     teamru_user: false,
     volunteers: {
         display: true,

--- a/src/Defaults.js
+++ b/src/Defaults.js
@@ -33,7 +33,7 @@ const defaults = {
         "https://s3-us-west-2.amazonaws.com/hackru-internal/partners-logos/",
     teamInfo: "https://s3-us-west-2.amazonaws.com/hackru-internal/hackru-team/",
     freeze: false,
-    teamru: false,
+    teamru: true,
     teamru_user: false,
     volunteers: {
         display: true,

--- a/src/components/Dashboard/TeamViewer/Explore.jsx
+++ b/src/components/Dashboard/TeamViewer/Explore.jsx
@@ -60,18 +60,20 @@ function Explore(props) {
             setSliceSearchTeams(allTeams.all_open_teams.filter(checkTeam).slice(((teamPage - 1) * 4), teamPage * 4));
             setTotalSearchTeams(allTeams.all_open_teams.filter(checkTeam));
         }
-    }, [searchText]); // Runs on search box change
+    }, [searchText]);
 
     useEffect(() => {
-        setTeamPageCount(Math.ceil(totalSearchTeams.length / 4));
-    }, [totalSearchTeams]); // Runs on search box change
+        if (allTeams.all_open_teams && allTeams.all_open_teams.length !== 0) {
+            setTeamPageCount(Math.ceil(totalSearchTeams.length / 4));
+        }
+    }, [totalSearchTeams]);
 
     // Checks if user searches while past total search teams page count
     useEffect(() => {
         if (teamPage > teamPageCount) {
             handleTeamPagination(null, 1);
         }
-    }, [teamPageCount]); // Runs on search box change
+    }, [teamPageCount]);
 
     const onInvite = async (id) => {
         // let all_teams = await props.profile.getAllTeams(((page - 1) * 4), 4);
@@ -93,7 +95,7 @@ function Explore(props) {
 
     const handleTeamPagination = async (event, value) => {
         setTeamPage(value);
-        if (totalSearchTeams !== undefined) {
+        if (totalSearchTeams) {
             let sliceTeams = totalSearchTeams.slice(((value - 1) * 4), value * 4);
             setSliceSearchTeams(sliceTeams);
         }

--- a/src/components/Dashboard/TeamViewer/Explore.jsx
+++ b/src/components/Dashboard/TeamViewer/Explore.jsx
@@ -51,6 +51,9 @@ function Explore(props) {
 
     // On page load and search box change, set the paginated and total teams that match search
     useEffect(() => {
+        props.profile.getAllTeams().then((success) => {
+            setAllTeams(success.response);
+        });
         if (allTeams.all_open_teams !== undefined) {
             const checkTeam = (team) => {
                 const lowerTeam = team.name.toLowerCase();
@@ -97,8 +100,8 @@ function Explore(props) {
         props.profile.getTeamUser().then((success) => {
             const team_id = success.response.team_id;
             props.profile.matches(team_id).then((success) => {
+                setMatches(success.response);
                 if (success.response.matches && !JSON.stringify(matches.matches) == JSON.stringify(success.response.matches)) {
-                    setMatches(success.response);
                     setSliceMatches(success.response.matches.slice(((value - 1) * 4), value * 4));
                 } else {
                     setSliceMatches(matches.matches.slice(((value - 1) * 4), value * 4));
@@ -111,15 +114,11 @@ function Explore(props) {
     const handleTeamPagination = async (event, value) => {
         setTeamPage(value);
         if (totalSearchTeams) {
+            props.profile.getAllTeams().then((success) => {
+                setAllTeams(success.response);
+            });
             props.profile.getAllTeams(((value - 1) * 4), 4).then((success) => {
-                if (success.response.all_open_teams && !JSON.stringify(success.response.all_open_teams) == JSON.stringify(totalSearchTeams.slice(((value - 1) * 4), value * 4))) {
-                    setSliceSearchTeams(success.response.all_open_teams);
-                    props.profile.getAllTeams().then((success) => {
-                        setTotalSearchTeams(success.response.all_open_teams);
-                    });
-                } else {
-                    setSliceSearchTeams(totalSearchTeams.slice(((value - 1) * 4), value * 4));
-                }
+                setSliceSearchTeams(success.response.all_open_teams);
             });
         }
     };

--- a/src/components/Dashboard/TeamViewer/Explore.jsx
+++ b/src/components/Dashboard/TeamViewer/Explore.jsx
@@ -12,7 +12,7 @@ function Explore(props) {
     const [matches, setMatches] = useState({}); // all matches
     const [matchesPage, setMatchesPage] = React.useState(0); // matches page
     const [matchesPageCount, setMatchesPageCount] = React.useState(0); // matches total page count
-    const [sliceMatches, setSliceMatches] = useState({});
+    const [sliceMatches, setSliceMatches] = useState({}); // matches shown on single pagination
     const [originalTeamId, setOriginalTeam] = useState({});
     const [teamPage, setTeamPage] = React.useState(0); // all teams page
     const [teamPageCount, setTeamPageCount] = React.useState(0); // all teams total page count
@@ -21,6 +21,8 @@ function Explore(props) {
     const [sliceSearchTeams, setSliceSearchTeams] = useState({}); // all teams matching input shown on single pagination
     const [loading, setLoading] = useState("Loading your matches...");
     const [searchText, setSearchText] = useState("");
+    
+    // On page load
     useEffect(() => {
         props.profile.getTeamUser().then((success) => {
             const team_id = success.response.team_id;
@@ -47,6 +49,7 @@ function Explore(props) {
         });
     }, []);
 
+    // On page load and search box change, set the paginated and total teams that match search
     useEffect(() => {
         if (allTeams.all_open_teams !== undefined) {
             const checkTeam = (team) => {
@@ -62,6 +65,7 @@ function Explore(props) {
         }
     }, [searchText]);
 
+    // Set total number of team pages
     useEffect(() => {
         if (allTeams.all_open_teams && allTeams.all_open_teams.length !== 0) {
             setTeamPageCount(Math.ceil(totalSearchTeams.length / 4));

--- a/src/components/Dashboard/TeamViewer/Explore.jsx
+++ b/src/components/Dashboard/TeamViewer/Explore.jsx
@@ -101,11 +101,8 @@ function Explore(props) {
             const team_id = success.response.team_id;
             props.profile.matches(team_id).then((success) => {
                 setMatches(success.response);
-                if (success.response.matches && !JSON.stringify(matches.matches) == JSON.stringify(success.response.matches)) {
+                if (success.response.matches)
                     setSliceMatches(success.response.matches.slice(((value - 1) * 4), value * 4));
-                } else {
-                    setSliceMatches(matches.matches.slice(((value - 1) * 4), value * 4));
-                }
             });
         });
     };

--- a/src/components/Dashboard/TeamViewer/Explore.jsx
+++ b/src/components/Dashboard/TeamViewer/Explore.jsx
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 import TeamLoading from "../TeamLoading";
 
 import RenderRow from "./RenderRow";
+import ExploreSearchBox from "./ExploreSearchBox";
 
 function Explore(props) {
     const [matches, setMatches] = useState({});
@@ -13,6 +14,7 @@ function Explore(props) {
     const [page, setPage] = React.useState(1);
     const [allTeams, setAllTeams] = useState({});
     const [loading, setLoading] = useState("Loading your matches...");
+    const [searchText, setSearchText] = useState("");
     useEffect(() => {
         props.profile.getTeamUser().then((success) => {
             const team_id = success.response.team_id;
@@ -26,6 +28,10 @@ function Explore(props) {
             });
         });
     }, []);
+
+    useEffect(() => {
+        console.log(searchText);
+    }, [searchText]);
 
     const onInvite = async (id) => {
         // let all_teams = await props.profile.getAllTeams(((page - 1) * 4), 4);
@@ -77,6 +83,7 @@ function Explore(props) {
                 )}
             </List>
             <Typography variant="h5">All Teams</Typography>
+            <ExploreSearchBox setSearchText={setSearchText} />
             <List
                 style={{ maxHeight: "300px", width: "600px", overflow: "auto" }}
                 className="no-scrollbars no-style-type"

--- a/src/components/Dashboard/TeamViewer/ExploreSearchBox.jsx
+++ b/src/components/Dashboard/TeamViewer/ExploreSearchBox.jsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import Box from "@material-ui/core/Box";
+import TextField from "@material-ui/core/TextField";
+import PropTypes from "prop-types";
+
+function ExploreSearchBox(props) {
+    return (
+        <Box
+            component="form"
+            sx={{
+                mt: 5,
+                mb: 5
+            }}
+            noValidate
+            autoComplete="off"
+            onChange={(e) => {
+                props.setSearchText(e.target.value);
+            }}
+        >
+            <TextField id="outlined-basic"
+                label="Search by team name"
+                variant="outlined" />
+        </Box>
+    );
+}
+
+ExploreSearchBox.propTypes = {
+    setSearchText: PropTypes.func
+};
+
+export default ExploreSearchBox;

--- a/src/components/Dashboard/TeamViewer/ExploreSearchBox.jsx
+++ b/src/components/Dashboard/TeamViewer/ExploreSearchBox.jsx
@@ -16,6 +16,11 @@ function ExploreSearchBox(props) {
             onChange={(e) => {
                 props.setSearchText(e.target.value);
             }}
+            onKeyPress={(e) => { // Prevent page from reloading on Enter
+                if (e.key === "Enter") {
+                    e.preventDefault();
+                }
+            }}
         >
             <TextField id="outlined-basic"
                 label="Search by team name"


### PR DESCRIPTION
# Description

- Added a search box for the Explore page where users can search for teams in the All Teams section on each letter change with pagination. The given/searched teams and matches are from loading the Explore page and pagination/search change.
- Added pagination for matches and connected team pagination with team search.

# Demos

## Full Demo

https://user-images.githubusercontent.com/30333942/134451253-4b7a8e57-a91a-44c6-98a8-403bf416262c.mp4

## Case-Insensitivity and Pagination Demo

https://user-images.githubusercontent.com/30333942/134440447-79886de2-0507-4afb-a572-f70e4563e2e4.mp4

## Notes

- Case-insensitive inclusion team search (not based on the beginning of team name but rather if the name includes the input anywhere).

### Debouncer Addition

We could additionally request the API for all teams on a certain wait time interval when searching by connecting with the debouncer hook in #446 once that's merged in, therefore disallowing too many requests within a certain timeframe.
